### PR TITLE
Remove handlers of outdated mrview parameters

### DIFF
--- a/include/couch_mrview.hrl
+++ b/include/couch_mrview.hrl
@@ -77,7 +77,6 @@
     update_seq=false,
     conflicts,
     callback,
-    list,
     sorted = true,
     extra = []
 }).

--- a/src/couch_mrview_http.erl
+++ b/src/couch_mrview_http.erl
@@ -377,8 +377,6 @@ parse_param(Key, Val, Args) ->
             Args#mrargs{end_key_docid=couch_util:to_binary(Val)};
         "limit" ->
             Args#mrargs{limit=parse_pos_int(Val)};
-        "count" ->
-            throw({query_parse_error, <<"QS param `count` is not `limit`">>});
         "stale" when Val == "ok" orelse Val == <<"ok">> ->
             Args#mrargs{stale=ok};
         "stale" when Val == "update_after" orelse Val == <<"update_after">> ->
@@ -423,8 +421,6 @@ parse_param(Key, Val, Args) ->
             Args#mrargs{update_seq=parse_boolean(Val)};
         "conflicts" ->
             Args#mrargs{conflicts=parse_boolean(Val)};
-        "list" ->
-            Args#mrargs{list=couch_util:to_binary(Val)};
         "callback" ->
             Args#mrargs{callback=couch_util:to_binary(Val)};
         _ ->


### PR DESCRIPTION
The `list` was introduced by COUCHDB-404 and becomes eventually
replaced by list functions since 0.10 release.

The `count` was suppressed by `limit` since 0.9 release.