### PR TITLE
Export get_view_callback/3 for use by chttpd

### DIFF
--- a/src/couch_mrview_http.erl
+++ b/src/couch_mrview_http.erl
@@ -33,7 +33,8 @@
     view_cb/2,
     row_to_json/1,
     row_to_json/2,
-    check_view_etag/3
+    check_view_etag/3,
+    get_view_callback/3
 ]).
 
 -include_lib("couch/include/couch_db.hrl").


### PR DESCRIPTION
In order to provide the expected security for the _users DB on
the clustered interface, chttpd needs to use get_view_callback/3
so it can use either view_cb/2 (normal case) or filtered_view_cb/2
(for the _users DB).

COUCHDB-2452
