### PR TITLE
Fix typo in metrics definition

### DIFF
--- a/priv/stats_descriptions.cfg
+++ b/priv/stats_descriptions.cfg
@@ -14,7 +14,7 @@
 % a trailing full-stop / period
 % Please keep this in alphabetical order
 
-{[couchdb, mrview, map_doc], [
+{[couchdb, mrview, map_docs], [
     {type, counter},
     {desc, <<"number of documents mapped in the view server">>}
 ]}.


### PR DESCRIPTION
We call increment_counter with map_docs.
Change definition in stats_description.cfg to match.

COUCHDB-2552