### PR TITLE
Use proper collation function during reduce grouping

### DIFF
--- a/src/couch_mrview.erl
+++ b/src/couch_mrview.erl
@@ -440,8 +440,8 @@ red_fold(Db, {_Nth, _Lang, View}=RedView, Args, Callback, UAcc) ->
         update_seq=View#mrview.update_seq,
         args=Args
     },
-    GroupFun = group_rows_fun(Args#mrargs.group_level),
-    OptList = couch_mrview_util:key_opts(Args, [{key_group_fun, GroupFun}]),
+    Grouping = {key_group_level, Args#mrargs.group_level},
+    OptList = couch_mrview_util:key_opts(Args, [Grouping]),
     Acc2 = lists:foldl(fun(Opts, Acc0) ->
         {ok, Acc1} =
             couch_mrview_util:fold_reduce(RedView, fun red_fold/3,  Acc0, Opts),
@@ -527,18 +527,6 @@ make_meta(Args, UpdateSeq, Base) ->
     case Args#mrargs.update_seq of
         true -> {meta, Base ++ [{update_seq, UpdateSeq}]};
         _ -> {meta, Base}
-    end.
-
-
-group_rows_fun(exact) ->
-    fun({Key1,_}, {Key2,_}) -> Key1 == Key2 end;
-group_rows_fun(0) ->
-    fun(_A, _B) -> true end;
-group_rows_fun(GroupLevel) when is_integer(GroupLevel) ->
-    fun({[_|_] = Key1,_}, {[_|_] = Key2,_}) ->
-        lists:sublist(Key1, GroupLevel) == lists:sublist(Key2, GroupLevel);
-    ({Key1,_}, {Key2,_}) ->
-        Key1 == Key2
     end.
 
 

--- a/src/couch_mrview_test_util.erl
+++ b/src/couch_mrview_test_util.erl
@@ -89,7 +89,7 @@ ddoc(map) ->
     ]});
 ddoc(red) ->
     couch_doc:from_json_obj({[
-        {<<"_id">>, <<"_design/bar">>},
+        {<<"_id">>, <<"_design/red">>},
         {<<"views">>, {[
             {<<"baz">>, {[
                 {<<"map">>, <<
@@ -98,6 +98,15 @@ ddoc(red) ->
                     "}\n"
                 >>},
                 {<<"reduce">>, <<"function(keys, vals) {return sum(vals);}">>}
+            ]}},
+            {<<"zing">>, {[
+                {<<"map">>, <<
+                    "function(doc) {\n"
+                    "  if(doc.foo !== undefined)\n"
+                    "    emit(doc.foo, null);\n"
+                    "}"
+                >>},
+                {<<"reduce">>, <<"_count">>}
             ]}}
         ]}}
     ]}).

--- a/test/couch_mrview_collation_tests.erl
+++ b/test/couch_mrview_collation_tests.erl
@@ -87,17 +87,13 @@ collation_test_() ->
 
 should_collate_fwd(Db) ->
     {ok, Results} = run_query(Db, []),
-    Expect = [{meta, [{total, 26}, {offset, 0}]}] ++ rows(),
-    %% cannot use _assertEqual since mrview converts
-    %% value 3.0 to 3 making assertion fail
-    ?_assert(Expect == Results).
+    Expect = [{meta, [{total, length(?VALUES)}, {offset, 0}]}] ++ rows(),
+    ?_assertEquiv(Expect, Results).
 
 should_collate_rev(Db) ->
     {ok, Results} = run_query(Db, [{direction, rev}]),
-    Expect = [{meta, [{total, 26}, {offset, 0}]}] ++ lists:reverse(rows()),
-    %% cannot use _assertEqual since mrview converts
-    %% value 3.0 to 3 making assertion fail
-    ?_assert(Expect == Results).
+    Expect = [{meta, [{total, length(?VALUES)}, {offset, 0}]}] ++ lists:reverse(rows()),
+    ?_assertEquiv(Expect, Results).
 
 should_collate_range(Db) ->
     ?_assertNot(
@@ -106,7 +102,7 @@ should_collate_range(Db) ->
                 {ok, Results} = run_query(Db, [{start_key, V}, {end_key, V}]),
                 Id = list_to_binary(integer_to_list(Count)),
                 Expect = [
-                    {meta, [{total, 26}, {offset, Count}]},
+                    {meta, [{total, length(?VALUES)}, {offset, Count}]},
                     {row, [{id, Id}, {key, V}, {value, 0}]}
                 ],
                 case Results == Expect of

--- a/test/couch_mrview_red_views_tests.erl
+++ b/test/couch_mrview_red_views_tests.erl
@@ -92,4 +92,4 @@ should_reduce_with_group_exact(Db) ->
 
 
 run_query(Db, Opts) ->
-    couch_mrview:query_view(Db, <<"_design/bar">>, <<"baz">>, Opts).
+    couch_mrview:query_view(Db, <<"_design/red">>, <<"baz">>, Opts).


### PR DESCRIPTION
The actual change to the database code here is very simple -- just use `key_group_level` instead of `key_group_fun` and we'll automatically use the correct collation function. The rest of the PR is work to improve the tests; they weren't checking for this condition, and I found them fairly brittle to modify. There's more that could be done there, but I wanted to get this fix in before I got distracted by other stuff.
