### PR TITLE
Reject unsupported builtin reduce functions

### DIFF
--- a/src/couch_mrview.erl
+++ b/src/couch_mrview.erl
@@ -64,8 +64,15 @@ validate(DbName, DDoc) ->
     ValidateView = fun(Proc, #mrview{def=MapSrc, reduce_funs=Reds}=View) ->
         couch_query_servers:try_compile(Proc, map, GetName(View), MapSrc),
         lists:foreach(fun
-            ({_RedName, <<"_", _/binary>>}) ->
+            ({_RedName, <<"_sum", _/binary>>}) ->
                 ok;
+            ({_RedName, <<"_count", _/binary>>}) ->
+                ok;
+            ({_RedName, <<"_stats", _/binary>>}) ->
+                ok;
+            ({_RedName, <<"_", _/binary>> = Bad}) ->
+                Msg = ["`", Bad, "` is not a supported reduce function."],
+                throw({invalid_design_doc, Msg});
             ({RedName, RedSrc}) ->
                 couch_query_servers:try_compile(Proc, reduce, RedName, RedSrc)
         end, Reds)

--- a/test/couch_mrview_ddoc_validation_tests.erl
+++ b/test/couch_mrview_ddoc_validation_tests.erl
@@ -1,0 +1,78 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_mrview_ddoc_validation_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+setup() ->
+    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), map),
+    Db.
+
+teardown(Db) ->
+    couch_db:close(Db),
+    couch_server:delete(Db#db.name, [?ADMIN_CTX]),
+    ok.
+
+ddoc_validation_test_() ->
+    {
+        "ddoc validation tests",
+        {
+            setup,
+            fun test_util:start_couch/0, fun test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun should_reject_invalid_js_map/1,
+                    fun should_reject_invalid_js_reduce/1,
+                    fun should_reject_invalid_builtin_reduce/1
+                ]
+            }
+        }
+    }.
+
+should_reject_invalid_js_map(Db) ->
+    Doc = couch_doc:from_json_obj({[
+        {<<"_id">>, <<"_design/should_reject_invalid_js_map">>},
+        {<<"views">>, {[
+            {<<"foo">>, {[
+                {<<"map">>, <<"function(doc) }{">>}
+            ]}}
+        ]}}
+    ]}),
+    ?_assertThrow({compilation_error, _}, couch_db:update_doc(Db, Doc, [])).
+
+should_reject_invalid_js_reduce(Db) ->
+    Doc = couch_doc:from_json_obj({[
+        {<<"_id">>, <<"_design/should_reject_invalid_js_reduce">>},
+        {<<"views">>, {[
+            {<<"foo">>, {[
+                {<<"map">>, <<"function(doc) { emit(null); }">>},
+                {<<"reduce">>, <<"function(k, v, r) }{}">>}
+            ]}}
+        ]}}
+    ]}),
+    ?_assertThrow({compilation_error, _}, couch_db:update_doc(Db, Doc, [])).
+
+should_reject_invalid_builtin_reduce(Db) ->
+    Doc = couch_doc:from_json_obj({[
+        {<<"_id">>, <<"_design/should_reject_invalid_builtin_reduce">>},
+        {<<"views">>, {[
+            {<<"foo">>, {[
+                {<<"map">>, <<"function(doc) { emit(null); }">>},
+                {<<"reduce">>, <<"_foobar">>}
+            ]}}
+        ]}}
+    ]}),
+    ?_assertThrow({invalid_design_doc, _}, couch_db:update_doc(Db, Doc, [])).


### PR DESCRIPTION
We reject bad JS code in design documents, but one thing we haven't done is reject design documents that specify unknown builtin reduce functions. This PR addresses that, and adds a few tests to confirm that we do throw exceptions on these conditions.

COUCHDB-537
