### PR TITLE
Buffer rows in chunked responses

### DIFF
--- a/include/couch_mrview.hrl
+++ b/include/couch_mrview.hrl
@@ -94,7 +94,10 @@
     resp,
     prepend,
     etag,
-    should_close = false
+    should_close = false,
+    buffer = [],
+    bufsize = 0,
+    threshold = 1490
 }).
 
 -record(lacc, {

--- a/src/couch_mrview_http.erl
+++ b/src/couch_mrview_http.erl
@@ -343,8 +343,7 @@ view_cb({meta, Meta}, #vacc{resp=Resp}=Acc) ->
         undefined -> [];
         UpdateSeq -> [io_lib:format("\"update_seq\":~p", [UpdateSeq])]
     end ++ ["\"rows\":["],
-    Prepend = prepend_val(Acc),
-    Chunk = lists:flatten(Prepend ++ "{" ++ string:join(Parts, ",") ++ "\r\n"),
+    Chunk = [prepend_val(Acc), "{", string:join(Parts, ","), "\r\n"],
     {ok, Resp1} = chttpd:send_delayed_chunk(Resp, Chunk),
     {ok, Acc#vacc{resp=Resp1, prepend=""}};
 view_cb({row, Row}, Acc) ->


### PR DESCRIPTION
This patch reduces the number of chunks in an HTTP chunked response body by coalescing multiple rows into a single transmission. The default value is chosen to fill a standard Ethernet frame but is
configurable in the .ini by setting 

```
[httpd]
chunked_response_buffer = 1490 ; size of buffer in bytes
```

See [COUCHDB-2724](https://issues.apache.org/jira/browse/COUCHDB-2724).
