### PR TITLE
Add call to couch_index_plugin:index_update/4

### DIFF
--- a/src/couch_mrview_updater.erl
+++ b/src/couch_mrview_updater.erl
@@ -472,6 +472,10 @@ update_task(NumChanges) ->
 
 
 maybe_notify(State, View, KVs, ToRem) ->
-    Updated = [Key || {{Key, _}, _} <- KVs],
-    Removed = [Key || {Key, _DocId} <- ToRem],
+    Updated = fun() ->
+        [Key || {{Key, _}, _} <- KVs]
+    end,
+    Removed = fun() ->
+        [Key || {Key, _DocId} <- ToRem]
+    end,
     couch_index_plugin:index_update(State, View, Updated, Removed).


### PR DESCRIPTION
This is one of the series of PRs to make couchdb plugable. I'll provide complete list of dependent PRs in https://github.com/apache/couchdb-couch repository.