### PR TITLE
Validate incompatible query parameters: group and group_level

### DIFF
--- a/include/couch_mrview.hrl
+++ b/include/couch_mrview.hrl
@@ -76,6 +76,7 @@
     limit = 16#10000000,
     skip = 0,
     group_level = 0,
+    group = undefined,
     stale = false,
     multi_get = false,
     inclusive_end = true,

--- a/src/couch_mrview_http.erl
+++ b/src/couch_mrview_http.erl
@@ -432,10 +432,11 @@ parse_params(Props, Keys) ->
 
 
 parse_params(Props, Keys, #mrargs{}=Args0) ->
-    Args = Args0#mrargs{keys=Keys},
+    % group_level set to undefined to detect if explicitly set by user
+    Args1 = Args0#mrargs{keys=Keys, group=undefined, group_level=undefined},
     lists:foldl(fun({K, V}, Acc) ->
         parse_param(K, V, Acc)
-    end, Args, Props).
+    end, Args1, Props).
 
 
 parse_param(Key, Val, Args) when is_binary(Key) ->
@@ -483,10 +484,7 @@ parse_param(Key, Val, Args) ->
         "skip" ->
             Args#mrargs{skip=parse_pos_int(Val)};
         "group" ->
-            case parse_boolean(Val) of
-                true -> Args#mrargs{group_level=exact};
-                _ -> Args#mrargs{group_level=0}
-            end;
+            Args#mrargs{group=parse_boolean(Val)};
         "group_level" ->
             Args#mrargs{group_level=parse_pos_int(Val)};
         "inclusive_end" ->

--- a/test/couch_mrview_http_tests.erl
+++ b/test/couch_mrview_http_tests.erl
@@ -1,0 +1,27 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_mrview_http_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch_mrview/include/couch_mrview.hrl").
+
+
+mrview_http_test_() ->
+    [
+         ?_assertEqual(#mrargs{group_level=undefined, group=true},
+                       couch_mrview_http:parse_params([{"group", "true"}],
+                                            undefined, #mrargs{})),
+
+         ?_assertEqual(#mrargs{group_level=1, group=undefined},
+                       couch_mrview_http:parse_params([{"group_level", "1"}]))
+    ].

--- a/test/couch_mrview_util_tests.erl
+++ b/test/couch_mrview_util_tests.erl
@@ -1,0 +1,39 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_mrview_util_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch_mrview/include/couch_mrview.hrl").
+
+
+
+couch_mrview_util_test_() ->
+    [
+         ?_assertEqual(0, validate_group_level(undefined, undefined)),
+         ?_assertEqual(exact, validate_group_level(true, undefined)),
+         ?_assertEqual(0, validate_group_level(false, undefined)),
+         ?_assertEqual(1, validate_group_level(undefined, 1)),
+         ?_assertEqual(0, validate_group_level(true, 0)),
+         ?_assertEqual(0, validate_group_level(undefined, 0)),
+         ?_assertEqual(1, validate_group_level(true, 1)),
+         ?_assertEqual(0, validate_group_level(false, 0)),
+         ?_assertThrow({query_parse_error,
+              <<"Can't specify group=false and group_level>0 at the same time">>},
+              validate_group_level(false,1))
+    ].
+
+validate_group_level(Group, GroupLevel) ->
+    Args0 = #mrargs{group=Group, group_level=GroupLevel, view_type=red},
+    Args1 = couch_mrview_util:validate_args(Args0),
+    Args1#mrargs.group_level.
+


### PR DESCRIPTION
Jira: COUCH-2824

Parameters group and group_level currently were
overriding each other -- last one in the list "won".

Those parameters are not compatible with each other,
instead return a 400 result to the user with an
appropriate error message.

Example of new behavior:

```
$ http "$DB1/db1/_design/des1/_view/v1?group_level=1&group=true"
HTTP/1.1 400 Bad Request

{"error":"query_parse_error","reason":"`group` and `group_level` are incompatible"}
```

Also added unit test module for mrview parameter parsing. Ran with :

```
 export BUILDIR=`pwd` && rebar -r eunit apps=couch_mrview tests="mrview_http_params_group_true_test,mrview_http_params_group_false_test,mrview_http_params_group_level_test,mrview_http_params_group_and_group_level_incompatibl_test"
```