### PR TITLE
[mrview] fix http test

### DIFF
--- a/test/couch_mrview_http_tests.erl
+++ b/test/couch_mrview_http_tests.erl
@@ -23,5 +23,6 @@ mrview_http_test_() ->
                                             undefined, #mrargs{})),
 
          ?_assertEqual(#mrargs{group_level=1, group=undefined},
-                       couch_mrview_http:parse_params([{"group_level", "1"}]))
+                       couch_mrview_http:parse_params([{"group_level", "1"}],
+                                            undefined, #mrargs{}))
     ].


### PR DESCRIPTION
 COUCHDB-2824

Now all couch_mrview eunit tests should pass:

```
$ export BUILDDIR=`pwd` && rebar -r eunit apps=couch_mrview
...
=======================================================
  All 104 tests passed.
==> rel (eunit)
==> couchdb (eunit)
```
