### PR TITLE
Use couch_file:delete/3 in views cleanup

### DIFF
--- a/src/couch_mrview_cleanup.erl
+++ b/src/couch_mrview_cleanup.erl
@@ -41,71 +41,7 @@ run(Db) ->
 
     lists:foreach(fun(FN) ->
         couch_log:debug("Deleting stale view file: ~s", [FN]),
-        delete_view_file(RootDir, FN)
+        couch_file:delete(RootDir, FN, [sync])
     end, ToDelete),
 
     ok.
-
-delete_view_file(RootDir, FullFilePath) ->
-    couch_server:delete_file(RootDir, FullFilePath, [sync]).
-
--ifdef(TEST).
--include_lib("couch/include/couch_eunit.hrl").
-
-setup(rename) ->
-    setup(true);
-setup(delete) ->
-    setup(false);
-setup(RenameOnDelete) ->
-    meck:new(config, [passthrough]),
-    meck:expect(config, get_boolean, fun
-        ("couchdb", "rename_on_delete", _Default) -> RenameOnDelete
-    end),
-    ViewFile = ?tempfile() ++ ".view",
-    RootDir = filename:dirname(ViewFile),
-    ok = couch_file:init_delete_dir(RootDir),
-    ok = file:write_file(ViewFile, <<>>),
-    {RootDir, ViewFile}.
-
-teardown(_, {_, ViewFile}) ->
-    (catch meck:unload(config)),
-    (catch file:delete(ViewFile)).
-
-delete_view_file_test_() ->
-    Funs = [
-        fun should_rename_on_delete/2,
-        fun should_delete/2
-    ],
-    [
-        make_test_case(rename, [fun should_rename_on_delete/2]),
-        make_test_case(delete, [fun should_delete/2])
-    ].
-
-make_test_case(Mod, Funs) ->
-    {
-        lists:flatten(io_lib:format("~s", [Mod])),
-        {foreachx, fun setup/1, fun teardown/2, [{Mod, Fun} || Fun <- Funs]}
-    }.
-
-should_rename_on_delete(_, {RootDir, ViewFile}) ->
-    ?_test(begin
-        ?assert(filelib:is_regular(ViewFile)),
-        Result = delete_view_file(RootDir, ViewFile),
-        ?assertNot(filelib:is_regular(ViewFile)),
-        ?assertMatch({ok, {renamed, _}}, Result),
-        {ok, {renamed, RenamedViewFile}} = Result,
-        ?assert(filelib:is_regular(RenamedViewFile))
-    end).
-
-should_delete(_, {RootDir, ViewFile}) ->
-    ?_test(begin
-        ?assert(filelib:is_regular(ViewFile)),
-        delete_view_file(RootDir, ViewFile),
-        ?assertNot(filelib:is_regular(ViewFile)),
-        ?assertMatch([], deleted_files(ViewFile))
-    end).
-
-deleted_files(ViewFile) ->
-    filelib:wildcard(filename:rootname(ViewFile) ++ "*.deleted.*").
-
--endif.


### PR DESCRIPTION
Use `couch_file:delete/3` directly instead of one-op front function.

All the tests moved in `couch_file_tests`.

Depends on apache/couchdb-couch#161