### PR TITLE
Make view updater couch_work_queue configurable

### DIFF
--- a/src/couch_mrview_updater.erl
+++ b/src/couch_mrview_updater.erl
@@ -21,7 +21,9 @@
 
 
 start_update(Partial, State, NumChanges) ->
-    QueueOpts = [{max_size, 100000}, {max_items, 500}],
+    MaxSize = config:get_integer("view_updater", "queue_memory_cap", 100000),
+    MaxItems = config:get_integer("view_updater", "queue_item_cap", 500),
+    QueueOpts = [{max_size, MaxSize}, {max_items, MaxItems}],
     {ok, DocQueue} = couch_work_queue:new(QueueOpts),
     {ok, WriteQueue} = couch_work_queue:new(QueueOpts),
 


### PR DESCRIPTION
For performance reasons in some cases there is a need to put a cap on a queue size.

COUCHDB-3005