### PR TITLE
Don't try to decode non-stringified JSON in params

### DIFF
--- a/src/couch_mrview_http.erl
+++ b/src/couch_mrview_http.erl
@@ -576,6 +576,9 @@ check_view_etag(Sig, Acc0, Req) ->
 
 
 parse_json(V) when is_list(V) ->
-    ?JSON_DECODE(V);
+    case lists:all(fun is_binary/1, V) of
+        true -> V;
+        false -> ?JSON_DECODE(V)
+    end;
 parse_json(V) ->
     V.


### PR DESCRIPTION
It is possible for the params "key", "keys", "startkey" and "endkey" to receive already decoded JSON array, if the query was done with `POST` and "keys" or "queries" payload.

COUCHDB-3031