### PR TITLE
Fix sorted=false feature

### DIFF
--- a/include/couch_mrview.hrl
+++ b/include/couch_mrview.hrl
@@ -98,7 +98,8 @@
     should_close = false,
     buffer = [],
     bufsize = 0,
-    threshold = 1490
+    threshold = 1490,
+    row_sent = false
 }).
 
 -record(lacc, {

--- a/src/couch_mrview_util.erl
+++ b/src/couch_mrview_util.erl
@@ -510,6 +510,11 @@ validate_args(Args) ->
         {_, EKDocId1} -> EKDocId1
     end,
 
+    case is_boolean(Args#mrargs.sorted) of
+        true -> ok;
+        _ -> mrverror(<<"Invalid value for `sorted`.">>)
+    end,
+
     Args#mrargs{
         start_key_docid=SKDocId,
         end_key_docid=EKDocId,


### PR DESCRIPTION
1. Enable the sorted=false parameter to map views
2. Enhance view_cb to tolerate rows before meta
3. Enhance view_cb to only send meta if no row has been sent

COUCHDB-3060