### PR TITLE
Support additional doc option opts in views

### DIFF
--- a/src/couch_mrview_http.erl
+++ b/src/couch_mrview_http.erl
@@ -540,10 +540,46 @@ parse_param(Key, Val, Args, IsDecoded) ->
             false ->
                 Args
             end;
+        "revs_info" ->
+            case parse_boolean(Val) of
+            true ->
+                Opts = Args#mrargs.doc_options,
+                Args#mrargs{doc_options=[revs_info|Opts]};
+            false ->
+                Args
+            end;
+        "deleted_conflicts" ->
+            case parse_boolean(Val) of
+            true ->
+                Opts = Args#mrargs.doc_options,
+                Args#mrargs{doc_options=[deleted_conflicts|Opts]};
+            false ->
+                Args
+            end;
+        "meta" ->
+            case parse_boolean(Val) of
+            true ->
+                Opts0 = Args#mrargs.doc_options,
+                Opts1 = [revs_info, conflicts, deleted_conflicts|Opts0],
+                Args#mrargs{doc_options=Opts1};
+            false ->
+                Args
+            end;
+        "r" ->
+            Opts = Args#mrargs.doc_options,
+            Args#mrargs{doc_options=[{r, Val}|Opts]};
         "update_seq" ->
             Args#mrargs{update_seq=parse_boolean(Val)};
         "conflicts" ->
-            Args#mrargs{conflicts=parse_boolean(Val)};
+            case parse_boolean(Val) of
+            true ->
+                Args#mrargs{
+                    conflicts=true,
+                    doc_options=[conflicts|Args#mrargs.doc_options]
+                };
+            false ->
+                Args#mrargs{conflicts=false}
+            end;
         "callback" ->
             Args#mrargs{callback=couch_util:to_binary(Val)};
         "sorted" ->


### PR DESCRIPTION
COUCHDB-2568 allowed several attachment-related doc open options to be
passed through _all_docs queries. This patch extends that work to
various other options by adding support for various doc open options to
the view argument parser:

- revs_info
- deleted_conflicts
- meta
- r

Additionally, this patch changes the behavior of the "conflicts" view
option to furthermore apply the "conflicts" doc open option if
include_docs=true is specified by the user.

Without this functionality there is no way for a user to implement an
"always on" conflict detection and resolution policy if they're using
_all_docs POST queries as their primary document access path.

COUCHDB-3064