### PR TITLE
Reset row_sent at end of query

### DIFF
--- a/src/couch_mrview_http.erl
+++ b/src/couch_mrview_http.erl
@@ -382,7 +382,7 @@ view_cb(complete, #vacc{resp=Resp, buffer=Buf, threshold=Max}=Acc) ->
             {ok, Resp2} = chttpd:end_delayed_json_response(Resp1),
             {ok, Acc#vacc{resp=Resp2}};
         _ ->
-            {ok, Acc#vacc{resp=Resp1,
+            {ok, Acc#vacc{resp=Resp1, row_sent=false,
                 prepend=",\r\n", buffer=[], bufsize=0}}
     end;
 view_cb({error, Reason}, #vacc{resp=undefined}=Acc) ->

--- a/src/couch_mrview_http.erl
+++ b/src/couch_mrview_http.erl
@@ -382,7 +382,8 @@ view_cb(complete, #vacc{resp=Resp, buffer=Buf, threshold=Max}=Acc) ->
             {ok, Resp2} = chttpd:end_delayed_json_response(Resp1),
             {ok, Acc#vacc{resp=Resp2}};
         _ ->
-            {ok, Acc#vacc{resp=Resp1, prepend=",\r\n", buffer=[], bufsize=0}}
+            {ok, Acc#vacc{resp=Resp1,
+                prepend=",\r\n", buffer=[], bufsize=0}}
     end;
 view_cb({error, Reason}, #vacc{resp=undefined}=Acc) ->
     {ok, Resp} = chttpd:send_error(Acc#vacc.req, Reason),


### PR DESCRIPTION
We need to reset row_sent to false at the end of the query so that we
will emit '{"rows":{' for the next query (if we're in a multi-query
request).

COUCHDB-3060