### PR TITLE
Make Query Limit Results Configurable

### DIFF
--- a/src/couch_mrview_http.erl
+++ b/src/couch_mrview_http.erl
@@ -469,9 +469,13 @@ parse_params(Props, Keys, #mrargs{}=Args0, Options) ->
     IsDecoded = lists:member(decoded, Options),
     % group_level set to undefined to detect if explicitly set by user
     Args1 = Args0#mrargs{keys=Keys, group=undefined, group_level=undefined},
-    lists:foldl(fun({K, V}, Acc) ->
+    Args2 = lists:foldl(fun({K, V}, Acc) ->
         parse_param(K, V, Acc, IsDecoded)
-    end, Args1, Props).
+    end, Args1, Props),
+    Limit = Args2#mrargs.limit,
+    MaxLimit = config:get_integer("couch_db", "max_query_limit",
+        16#10000000),
+    Args2#mrargs{limit=min(Limit, MaxLimit)}.
 
 
 parse_param(Key, Val, Args, IsDecoded) when is_binary(Key) ->

--- a/test/couch_mrview_all_docs_tests.erl
+++ b/test/couch_mrview_all_docs_tests.erl
@@ -107,6 +107,21 @@ should_query_with_limit_and_skip(Db) ->
     ]},
     ?_assertEqual(Expect, Result).
 
+should_query_with_config_limit_and_skip(Db) ->
+    ok = config:set("couch_db", "max_query_limit", 3),
+    Result = run_query(Db, [
+        {start_key, <<"2">>},
+        {limit, 6},
+        {skip, 3}
+    ]),
+    Expect = {ok, [
+        {meta, [{total, 11}, {offset, 5}]},
+        mk_row(<<"5">>, <<"1-aaac5d460fd40f9286e57b9bf12e23d2">>),
+        mk_row(<<"6">>, <<"1-aca21c2e7bc5f8951424fcfc5d1209d8">>),
+        mk_row(<<"7">>, <<"1-4374aeec17590d82f16e70f318116ad9">>)
+    ]},
+    ?_assertEqual(Expect, Result).
+
 should_query_with_include_docs(Db) ->
     Result = run_query(Db, [
         {start_key, <<"8">>},

--- a/test/couch_mrview_map_views_tests.erl
+++ b/test/couch_mrview_map_views_tests.erl
@@ -94,6 +94,15 @@ should_map_with_limit_and_skip(Db) ->
     ]},
     ?_assertEqual(Expect, Result).
 
+should_map_with_config_limit(Db) ->
+    ok = config:set("couch_db", "max_query_limit", 1),
+    Result = run_query(Db, []),
+    Expect = {ok, [
+        {meta, [{total, 1}, {offset, 0}]},
+        {row, [{id, <<"1">>}, {key, 1}, {value, 1}]}
+    ]},
+    ?_assertEqual(Expect, Result).
+
 should_map_with_include_docs(Db) ->
     Result = run_query(Db, [
         {start_key, 8},


### PR DESCRIPTION
Currently, all_docs are view results are practically unlimited
unless a user passes in a defined limit. This change allows an
administrator/operator to set a limit which takes priority over the
user defined limit. If this property is not set, then the default
value 16#10000000 is used.