### PR TITLE
Remove side effect from accumulate_more

### DIFF
--- a/src/couch_mrview_updater.erl
+++ b/src/couch_mrview_updater.erl
@@ -244,18 +244,18 @@ accumulate_writes(State, W, Acc0) ->
             {stop, {Seq, ViewKVs, DocIdKVs, Seqs, Log}};
         {ok, Info} ->
             {_, _, NewIds, _, _} = Acc = merge_results(Info, Seq, ViewKVs, DocIdKVs, Seqs, Log),
-            case accumulate_more(length(NewIds)) of
+            case accumulate_more(length(NewIds), Acc) of
                 true -> accumulate_writes(State, W, Acc);
                 false -> {ok, Acc}
             end
     end.
 
 
-accumulate_more(NumDocIds) ->
+accumulate_more(NumDocIds, Acc) ->
     % check if we have enough items now
     MinItems = config:get("view_updater", "min_writer_items", "100"),
     MinSize = config:get("view_updater", "min_writer_size", "16777216"),
-    {memory, CurrMem} = process_info(self(), memory),
+    CurrMem = ?term_size(Acc),
     NumDocIds < list_to_integer(MinItems)
         andalso CurrMem < list_to_integer(MinSize).
 


### PR DESCRIPTION
In mrview's updater we regulate the size of processed docs batch either by number of items or by memory it allocates. We are comparing threshold memory to updater process memory, but it is not exclusively defined by size of the batch and as a result we can get different value for data_size on different nodes for the same view shards.

This patch compares memory threshold to memory allocated just by accumulator, removing side effect from the function.

 