### PR TITLE
Add reference to indexer Pid to task status

### DIFF
--- a/src/couch_mrview_updater.erl
+++ b/src/couch_mrview_updater.erl
@@ -38,6 +38,7 @@ start_update(Partial, State, NumChanges) ->
     Self = self(),
     MapFun = fun() ->
         couch_task_status:add_task([
+            {indexer_pid, Partial},
             {type, indexer},
             {database, State#mrst.db_name},
             {design_document, State#mrst.idx_name},


### PR DESCRIPTION
When we run re-compaction stage we start second index updater from view compactor. In this case couch_task_status:all would return two identical entries for the same `design_document` and `shard`. Which is very confusing. Add reference to indexer Pid to disambiguate them.
For the recompaction case the indexer_pid will be pointing to compaction task.