### PR TITLE
Convert pid of indexer to binary

### DIFF
--- a/src/couch_mrview_updater.erl
+++ b/src/couch_mrview_updater.erl
@@ -38,7 +38,7 @@ start_update(Partial, State, NumChanges) ->
     Self = self(),
     MapFun = fun() ->
         couch_task_status:add_task([
-            {indexer_pid, Partial},
+            {indexer_pid, ?l2b(pid_to_list(Partial))},
             {type, indexer},
             {database, State#mrst.db_name},
             {design_document, State#mrst.idx_name},


### PR DESCRIPTION
This is a fixup for https://github.com/apache/couchdb-couch-mrview/pull/62
Properties passed to couch_task_status:add_task cannot contain complex
types. Because the status need to be representable in JSON.