### PR TITLE
Add error clause for built in reduce errors

### DIFF
--- a/src/couch_mrview_http.erl
+++ b/src/couch_mrview_http.erl
@@ -411,6 +411,12 @@ row_to_json(Row) ->
     row_to_json(Id, Row).
 
 
+row_to_json(builtin_reduce_error, Row) ->
+    Value = couch_util:get_value(value, Row),
+    Reason = couch_util:get_value(reason, Row),
+    Obj = {[{error, builtin_reduce_error}, {reason, Reason},
+        {cause_by, Value}]},
+    ?JSON_ENCODE(Obj);
 row_to_json(error, Row) ->
     % Special case for _all_docs request with KEYS to
     % match prior behavior.


### PR DESCRIPTION
When users provide invalid input to a reduce function, an error is
return by couch_query_servers instead of crashing. We take this error
and transform it into a meaningful message to the user.

This is a supplement PR to https://github.com/apache/couchdb-couch/pull/229.