### PR TITLE
Fix  end-point _local_docs

### DIFF
--- a/src/couch_mrview.erl
+++ b/src/couch_mrview.erl
@@ -533,15 +533,17 @@ map_fold({{Key, Id}, Val}, _Offset, Acc) ->
         user_acc=UAcc1,
         last_go=Go
     }};
-map_fold({<<"_local/",_/binary>> = DocId, {Rev0, _Body}}, _Offset, #mracc{} = Acc) ->
+map_fold({<<"_local/",_/binary>> = DocId, {Rev0, Body}}, _Offset, #mracc{} = Acc) ->
     #mracc{
         limit=Limit,
         callback=Callback,
-        user_acc=UAcc0
+        user_acc=UAcc0,
+        args=Args
     } = Acc,
     Rev = {0, list_to_binary(integer_to_list(Rev0))},
     Value = {[{rev, couch_doc:rev_to_str(Rev)}]},
-    Row = [{id, DocId}, {key, DocId}, {value, Value}],
+    Doc = if Args#mrargs.include_docs -> [{doc, Body}]; true -> [] end,
+    Row = [{id, DocId}, {key, DocId}, {value, Value}] ++ Doc,
     {Go, UAcc1} = Callback({row, Row}, UAcc0),
     {Go, Acc#mracc{
         limit=Limit-1,

--- a/src/couch_mrview_util.erl
+++ b/src/couch_mrview_util.erl
@@ -319,7 +319,8 @@ get_row_count(#mrview{btree=Bt}) ->
     {ok, Count}.
 
 
-all_docs_reduce_to_count(Reductions) ->
+all_docs_reduce_to_count(Reductions0) ->
+    Reductions = maybe_convert_reductions(Reductions0),
     Reduce = fun couch_db_updater:btree_by_id_reduce/2,
     {Count, _, _} = couch_btree:final_reduce(Reduce, Reductions),
     Count.
@@ -831,6 +832,16 @@ maybe_load_doc(Db, Id, Val, #mrargs{conflicts=true, doc_options=Opts}) ->
     doc_row(couch_index_util:load_doc(Db, docid_rev(Id, Val), [conflicts]), Opts);
 maybe_load_doc(Db, Id, Val, #mrargs{doc_options=Opts}) ->
     doc_row(couch_index_util:load_doc(Db, docid_rev(Id, Val), []), Opts).
+
+
+maybe_convert_reductions({KVs0, UserReductions}) ->
+    KVs = lists:map(fun maybe_convert_kv/1, KVs0),
+    {KVs, UserReductions}.
+
+maybe_convert_kv({<<"_local/", _/binary>> = DocId, _}) ->
+    #full_doc_info{id = DocId};
+maybe_convert_kv(DocInfo) ->
+    DocInfo.
 
 
 doc_row(null, _Opts) ->

--- a/test/couch_mrview_local_docs_tests.erl
+++ b/test/couch_mrview_local_docs_tests.erl
@@ -1,0 +1,132 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_mrview_local_docs_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+-define(TIMEOUT, 1000).
+
+
+
+setup() ->
+    {ok, Db} = couch_mrview_test_util:init_db(?tempdb(), local),
+    Db.
+
+teardown(Db) ->
+    couch_db:close(Db),
+    couch_server:delete(Db#db.name, [?ADMIN_CTX]),
+    ok.
+
+
+all_docs_test_() ->
+    {
+        "_local_docs view tests",
+        {
+            setup,
+            fun test_util:start_couch/0, fun test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun should_query/1,
+                    fun should_query_with_range/1,
+                    fun should_query_with_range_rev/1,
+                    fun should_query_with_limit_and_skip/1,
+                    fun should_query_with_include_docs/1
+                ]
+            }
+        }
+    }.
+
+
+should_query(Db) ->
+    Result = run_query(Db, []),
+    Expect = {ok, [
+        {meta, [{total, 10}, {offset, 0}]},
+        mk_row(1),
+        mk_row(10),
+        mk_row(2),
+        mk_row(3),
+        mk_row(4),
+        mk_row(5),
+        mk_row(6),
+        mk_row(7),
+        mk_row(8),
+        mk_row(9)
+    ]},
+    ?_assertEqual(Expect, Result).
+
+should_query_with_range(Db) ->
+    Result = run_query(Db, [
+        {start_key, <<"_local/3">>},
+        {end_key, <<"_local/5">>}
+    ]),
+    Expect = {ok, [
+        {meta, [{total, 10}, {offset, 3}]},
+        mk_row(3),
+        mk_row(4),
+        mk_row(5)
+    ]},
+    ?_assertEqual(Expect, Result).
+
+should_query_with_range_rev(Db) ->
+    Result = run_query(Db, [
+        {direction, rev},
+        {start_key, <<"_local/5">>}, {end_key, <<"_local/3">>},
+        {inclusive_end, true}
+    ]),
+    Expect = {ok, [
+        {meta, [{total, 10}, {offset, 4}]},
+        mk_row(5),
+        mk_row(4),
+        mk_row(3)
+    ]},
+    ?_assertEqual(Expect, Result).
+
+should_query_with_limit_and_skip(Db) ->
+    Result = run_query(Db, [
+        {start_key, <<"_local/2">>},
+        {limit, 3},
+        {skip, 3}
+    ]),
+    Expect = {ok, [
+        {meta, [{total, 10}, {offset, 5}]},
+        mk_row(5),
+        mk_row(6),
+        mk_row(7)
+    ]},
+    ?_assertEqual(Expect, Result).
+
+should_query_with_include_docs(Db) ->
+    Result = run_query(Db, [
+        {start_key, <<"_local/8">>},
+        {end_key, <<"_local/8">>},
+        {include_docs, true}
+    ]),
+    {row, Doc0} = mk_row(8),
+    Doc = Doc0 ++ [{doc, {[{<<"val">>, 8}]}}],
+    Expect = {ok, [
+        {meta, [{total, 10}, {offset, 8}]},
+        {row, Doc}
+    ]},
+    ?_assertEqual(Expect, Result).
+
+
+mk_row(IntId) ->
+    Id = list_to_binary(io_lib:format("_local/~b", [IntId])),
+    {row, [{id, Id}, {key, Id}, {value, {[{rev, <<"0-1">>}]}}]}.
+
+run_query(Db, Opts0) ->
+    Opts = [{extra, [{namespace, <<"_local">>}]} | Opts0],
+    couch_mrview:query_all_docs(Db, Opts).


### PR DESCRIPTION
This fixes the following issues with `/{db}/_local_docs` end-point:

1. Query ignores `include_docs` parameter
1. Query reports incorrect `total_rows` value, returning total rows for non-local docs instead
1. Query crashes with `badrecord` when trying to skip records, e.g. when `start_key` not the first local doc

COUCHDB-3337